### PR TITLE
Maintenance 

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,6 @@
+---
+exclude_paths:
+  - library/
+
+skip_list:
+  - args

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,4 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
-          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }} -vvvvvvvv --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 | sed 's/ansible-role-//' | sed 's/-/_/') $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+library/__pycache__

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 300
+    level: warning
+
+  comments-indentation: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.0
+
+- remove support of Ubuntu 18.04 (EOL)
+- `handlers/main.yml`: supplying `yes` to `targetcli` command is no longer needed
+- Archlinux: allow `iscsi_archlinux_aur_helper` to be set to empty string
+- add `.yamllint`
+- add `.ansible-lint`
+- Github Actions: fix Ansible Galaxy import
+- fix various `ansible-lint` issues
+- Molecule: fix `prepare.yml` for Archlinux
+- Molecule: increase instances memory
+
 ## 1.2.0
 
 - add Ubuntu 22.04 support

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This role configures a Linux-LIO based iSCSI target on a Linux host using `targe
 
 Tested with:
 
-- Ubuntu 18.04
 - Ubuntu 20.04
 - Ubuntu 22.04
 - Archlinux
@@ -99,8 +98,8 @@ The configuration above will create an iSCSI setup that will look like this (Out
 # this package needs to be installed from AUR. This requires an AUR install
 # helper like "yay", "paru", "pacaur", "trizen" or "pikaur". If such a helper
 # is already installed on the target host then there is no need to install it
-# via this role. In this case "iscsi_archlinux_aur_helper" needs to be 
-# commented and this role will skip the installation of an AUR helper.
+# via this role. In this case "iscsi_archlinux_aur_helper" needs to be
+# set to "" (empty sting) and this role will skip the installation of an AUR helper.
 # The install task picks one of the AUR helper mentioned above (in that order)
 # to install the iSCSI packages.
 iscsi_archlinux_aur_helper: yay

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ iscsi_targets: []
 # helper like "yay", "paru", "pacaur", "trizen" or "pikaur". If such a helper
 # is already installed on the target host then there is no need to install it
 # via this role. In this case "iscsi_archlinux_aur_helper" needs to be
-# commented and this role will skip the installation of an AUR helper.
+# set to "" (empty sting) and this role will skip the installation of an AUR helper.
 # The install task picks one of the AUR helper mentioned above (in that order)
 # to install the iSCSI packages.
 iscsi_archlinux_aur_helper: yay

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,9 @@
 ---
 - name: Save targetcli configuration
-  ansible.builtin.shell: "yes|targetcli saveconfig"
+  ansible.builtin.shell: |
+    yes|targetcli saveconfig
+  args:
+    executable: /bin/bash
+  register: iscsi_target__targetcli_saveconfig_out
+  changed_when: false
+  failed_when: iscsi_target__targetcli_saveconfig_out.rc != 0

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: Save targetcli configuration
   ansible.builtin.shell: |
     set -o pipefail
-    yes | targetcli saveconfig
+    targetcli saveconfig
   args:
     executable: /bin/bash
   register: iscsi_target__targetcli_saveconfig_out

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,8 @@
 ---
 - name: Save targetcli configuration
   ansible.builtin.shell: |
-    yes|targetcli saveconfig
+    set -o pipefail
+    yes | targetcli saveconfig
   args:
     executable: /bin/bash
   register: iscsi_target__targetcli_saveconfig_out

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - "focal"
-        - "bionic"
         - "jammy"
   galaxy_tags:
     - system

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,8 +4,8 @@
   remote_user: vagrant
   become: true
   gather_facts: true
-  collections:
-    - kewlfft.aur
+#  collections:
+#    - kewlfft.aur
 
 - name: Setup Archlinux hosts
   hosts: archlinux

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,7 +7,8 @@
   collections:
     - kewlfft.aur
 
-- hosts: archlinux
+- name: Setup Archlinux hosts
+  hosts: archlinux
   vars_files:
     - vars/archlinux.yml
   remote_user: vagrant
@@ -18,7 +19,8 @@
       ansible.builtin.include_role:
         name: githubixx.iscsi_target
 
-- hosts: ubuntu
+- name: Setup Ubuntu hosts
+  hosts: ubuntu
   vars_files:
     - vars/ubuntu.yml
   remote_user: vagrant

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -15,7 +15,7 @@
   gather_facts: true
   tasks:
     - name: Include iscsi_target role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.iscsi_target
 
 - hosts: ubuntu
@@ -26,5 +26,5 @@
   gather_facts: true
   tasks:
     - name: Include iscsi_target role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.iscsi_target

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,7 +26,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.10
+        ip: 172.16.10.10
     groups:
       - ubuntu
   - name: archlinux
@@ -40,7 +40,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.30
+        ip: 172.16.10.20
     groups:
       - archlinux
   - name: ubuntu2204
@@ -53,7 +53,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.40
+        ip: 172.16.10.30
     groups:
       - ubuntu
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -29,19 +29,6 @@ platforms:
         ip: 192.168.10.10
     groups:
       - ubuntu
-  - name: ubuntu1804
-    box: generic/ubuntu1804
-    memory: 1024
-    cpus: 2
-    provider_raw_config_args:
-      - "storage :file, :size => '1G', :device => 'vdb'"
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 192.168.10.20
-    groups:
-      - ubuntu
   - name: archlinux
     box: archlinux/archlinux
     memory: 1024

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,7 +18,7 @@ driver:
 platforms:
   - name: ubuntu2004
     box: generic/ubuntu2004
-    memory: 1024
+    memory: 2048
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :size => '1G', :device => 'vdb'"
@@ -31,7 +31,7 @@ platforms:
       - ubuntu
   - name: archlinux
     box: archlinux/archlinux
-    memory: 1024
+    memory: 2048
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :size => '1G', :device => 'vdb'"
@@ -45,7 +45,7 @@ platforms:
       - archlinux
   - name: ubuntu2204
     box: generic/ubuntu2204
-    memory: 1024
+    memory: 2048
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :size => '1G', :device => 'vdb'"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
-- name: Prepare
+- name: Setup Archlinux hosts
   hosts: archlinux
   gather_facts: false
   become: true
@@ -24,7 +24,8 @@
     - name: Reboot for kernel updates
       ansible.builtin.reboot:
 
-- hosts: ubuntu
+- name: Setup Ubuntu hosts
+  hosts: ubuntu
   remote_user: vagrant
   become: true
   gather_facts: true

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,21 +5,24 @@
   become: true
   tasks:
     - name: Init pacman
-      raw: |
+      ansible.builtin.raw: |
         pacman-key --init
         pacman-key --populate archlinux
 
     - name: Updating pacman cache
-      raw: pacman -Sy
+      ansible.builtin.raw: |
+        pacman -Sy
 
     - name: Install python for Ansible
-      raw: test -e /usr/bin/python || (pacman --noconfirm python)
+      ansible.builtin.raw: |
+        test -e /usr/bin/python || (pacman --noconfirm python)
 
     - name: Upgrade the whole system
-      raw: pacman --noconfirm -Su
+      ansible.builtin.raw: |
+        pacman --noconfirm -Su
 
     - name: Reboot for kernel updates
-      reboot:
+      ansible.builtin.reboot:
 
 - hosts: ubuntu
   remote_user: vagrant

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,18 +8,22 @@
       ansible.builtin.raw: |
         pacman-key --init
         pacman-key --populate archlinux
+      changed_when: false
 
     - name: Updating pacman cache
       ansible.builtin.raw: |
         pacman -Sy
+      changed_when: false
 
     - name: Install python for Ansible
       ansible.builtin.raw: |
         test -e /usr/bin/python || (pacman --noconfirm python)
+      changed_when: false
 
     - name: Upgrade the whole system
       ansible.builtin.raw: |
         pacman --noconfirm -Su
+      changed_when: false
 
     - name: Reboot for kernel updates
       ansible.builtin.reboot:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -15,9 +15,9 @@
         pacman -Sy
       changed_when: false
 
-    - name: Install python for Ansible
+    - name: Install Python for Ansible
       ansible.builtin.raw: |
-        test -e /usr/bin/python || (pacman --noconfirm python)
+        pacman -S --noconfirm python
       changed_when: false
 
     - name: Upgrade the whole system

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -14,4 +14,3 @@
       ansible.builtin.assert:
         that:
           - "expected_output in targetcli_output.stdout"
-

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,13 +5,13 @@
     expected_output: "iqn.2021-11.blog.tauceti:{{ ansible_facts['nodename'] }}"
   tasks:
     - name: Execute targetcli to capture output
-      command: targetcli "ls /"
+      ansible.builtin.command: targetcli "ls /"
       register: targetcli_output
       changed_when: false
       become: true
 
     - name: Ensure targetcli output contains correct string
-      assert:
+      ansible.builtin.assert:
         that:
           - "expected_output in targetcli_output.stdout"
 

--- a/tasks/configure-disk.yml
+++ b/tasks/configure-disk.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create or remove backstore objects for disk {{ disk.name }} and target {{ target.name }}
+- name: Create or remove backstore objects for disk and target
   targetcli_backstore:
     backstore_type: "{{ disk.type | default(iscsi_default_disk_type) }}"
     backstore_name: "{{ disk.name }}"
@@ -8,7 +8,7 @@
   notify:
     - Save targetcli configuration
 
-- name: Create or remove LUN {{ disk.name }} and target {{ target.name }}
+- name: Create or remove LUN and target
   targetcli_iscsi_lun:
     wwn: "{{ target.name }}"
     backstore_type: "{{ disk.type | default(iscsi_default_disk_type) }}"

--- a/tasks/configure-initiator.yml
+++ b/tasks/configure-initiator.yml
@@ -1,12 +1,12 @@
 ---
-- name: Define ACLs for iSCSI initiator {{ initiator.name }} for target {{ target.name }}
+- name: Define ACLs for iSCSI initiator for target
   targetcli_iscsi_acl:
     wwn: "{{ target.name }}"
     initiator_wwn: "{{ initiator.name }}"
   notify:
     - Save targetcli configuration
 
-- name: Configure authentication for initiator {{ initiator.name }} for target {{ target.name }}
+- name: Configure authentication for initiator for target
   targetcli_iscsi_auth:
     wwn: "{{ target.name }}"
     initiator_wwn: "{{ initiator.name }}"
@@ -18,7 +18,7 @@
     - Save targetcli configuration
 
 # Assign mapped LUNs to initiator
-- name: Adding mapped LUNs for initiator {{ initiator.name }} and target {{ target.name }}
+- name: Adding mapped LUNs for initiator and target
   targetcli_iscsi_mappedlun:
     wwn: "{{ target.name }}"
     initiator_wwn: "{{ initiator.name }}"

--- a/tasks/configure-target.yml
+++ b/tasks/configure-target.yml
@@ -12,7 +12,7 @@
     value: 'false'
 
 # Configure disks
-- include_tasks: configure-disk.yml
+- ansible.builtin.include_tasks: configure-disk.yml
   with_items:
     - "{{ target.disks }}"
   loop_control:
@@ -20,7 +20,7 @@
   when: target.state | default("present") == "present"
 
 # Configure initiators
-- include_tasks: configure-initiator.yml
+- ansible.builtin.include_tasks: configure-initiator.yml
   with_items:
     - "{{ target.initiators }}"
   loop_control:
@@ -37,7 +37,7 @@
   when: target.state | default("present") == "present"
 
 # Configure portal
-- include_tasks: configure-portal.yml
+- ansible.builtin.include_tasks: configure-portal.yml
   with_items:
     - "{{ target.portals }}"
   loop_control:

--- a/tasks/configure-target.yml
+++ b/tasks/configure-target.yml
@@ -11,16 +11,18 @@
     preference: 'auto_add_mapped_luns'
     value: 'false'
 
-# Configure disks
-- ansible.builtin.include_tasks: configure-disk.yml
+- name: Configure disks
+  ansible.builtin.include_tasks:
+    file: configure-disk.yml
   with_items:
     - "{{ target.disks }}"
   loop_control:
     loop_var: "disk"
   when: target.state | default("present") == "present"
 
-# Configure initiators
-- ansible.builtin.include_tasks: configure-initiator.yml
+- name: Configure initiators
+  ansible.builtin.include_tasks:
+    file: configure-initiator.yml
   with_items:
     - "{{ target.initiators }}"
   loop_control:
@@ -36,8 +38,9 @@
     - Save targetcli configuration
   when: target.state | default("present") == "present"
 
-# Configure portal
-- ansible.builtin.include_tasks: configure-portal.yml
+- name: Configure portal
+  ansible.builtin.include_tasks:
+    file: configure-portal.yml
   with_items:
     - "{{ target.portals }}"
   loop_control:

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -24,7 +24,7 @@
       ansible.builtin.lineinfile:
         path: /etc/sudoers.d/99-install-aur_builder
         line: 'aur_builder ALL=(ALL) NOPASSWD: /usr/bin/pacman'
-        mode: 0600
+        mode: "0600"
         create: true
         validate: 'visudo -cf %s'
 

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -2,6 +2,7 @@
 - name: Install prerequisites to install AUR helper
   when:
     - iscsi_archlinux_aur_helper is defined
+    - iscsi_archlinux_aur_helper != ""
   block:
     - name: Install needed packages
       ansible.builtin.package:

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -26,7 +26,7 @@
         create: true
         validate: 'visudo -cf %s'
 
-    - name: "Install {{ iscsi_archlinux_aur_helper }} using makepkg if it isn't installed already"
+    - name: "Install AUR helper using makepkg if it isn't installed already: {{ iscsi_archlinux_aur_helper }}"
       kewlfft.aur.aur:
         name: "{{ iscsi_archlinux_aur_helper }}"
         use: makepkg

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -1,5 +1,7 @@
 ---
 - name: Install prerequisites to install AUR helper
+  when:
+    - iscsi_archlinux_aur_helper is defined
   block:
     - name: Install needed packages
       ansible.builtin.package:
@@ -33,8 +35,6 @@
         state: present
       become: true
       become_user: "{{ iscsi_archlinux_aur_helper_user }}"
-  when:
-    - iscsi_archlinux_aur_helper is defined
 
 - name: Install targetcli packages
   kewlfft.aur.aur:


### PR DESCRIPTION
 - remove support of Ubuntu 18.04 (EOL)
- `handlers/main.yml`: supplying `yes` to `targetcli` command is no longer needed
- Archlinux: allow `iscsi_archlinux_aur_helper` to be set to empty string
- add `.yamllint`
- add `.ansible-lint`
- Github Actions: fix Ansible Galaxy import
- fix various `ansible-lint` issues
- Molecule: fix `prepare.yml` for Archlinux
- Molecule: increase instances memory