### PR TITLE
3.0.0

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,8 @@
 ---
+kinds:
+  - tasks: molecule/default/verify_target.yml
+  - tasks: molecule/default/verify_initiator.yml
+
 exclude_paths:
   - library/
 

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,6 +2,7 @@
 kinds:
   - tasks: molecule/default/verify_target.yml
   - tasks: molecule/default/verify_initiator.yml
+  - tasks: molecule/default/verify_initiator_client.yml
 
 exclude_paths:
   - library/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,14 @@ jobs:
         run: pip3 install ansible-core
 
       - name: Trigger a new import on Galaxy.
-        run: >-
-          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }} -vvvvvvvv --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 | sed 's/ansible-role-//' | sed 's/-/_/') $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+        run: |
+          repo_owner=$(echo "${{ github.repository }}" | cut -d/ -f1)
+          repo_name=$(echo "${{ github.repository }}" | cut -d/ -f2)
+          role_name=$(echo "$repo_name" | sed 's/ansible-role-//' | sed 's/-/_/')
+
+          ansible-galaxy role import \
+            --token "${{ secrets.GALAXY_API_KEY }}" \
+            -vvv \
+            --role-name="$role_name" \
+            "$repo_owner" \
+            "$repo_name"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 library/__pycache__
+.ansible

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+.ansible-lint

--- a/.yamllint
+++ b/.yamllint
@@ -1,9 +1,18 @@
 ---
+# Copyright (C) 2018-2025 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
 extends: default
 
 rules:
   line-length:
-    max: 300
+    max: 150
     level: warning
-
   comments-indentation: disable
+  comments:
+    min-spaces-from-content: 1
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 3.0.0
+
+- remove support for Ubuntu 20.04 (EOL)
+- add Ubuntu 24.04 support
+- add Ubuntu 26.04 support
+- fix custom Ansible modules for Python 3.12 by replacing `distutils.spawn.find_executable`
+- Ubuntu: stop installing `python3-distutils`, which is no longer available on Ubuntu 24.04+
+- Molecule: remove Ubuntu 20.04 test and add Ubuntu 24.04 and Ubuntu 26.04 tests
+- Molecule: remove leftover libvirt volumes during `molecule destroy`
+- add dual-stack Molecule coverage and document IPv6 portal support
+- handle targetcli default IPv6 portal `::0` as a special create case
+- Molecule: strengthen `verify` coverage for targets, backstores, LUNs, ACLs, auth, mapped LUNs, preferences, and portals
+- targetcli preferences: verify preference changes and fall back to updating `prefs.bin` when Ubuntu 26.04 `targetcli` reports success without changing state
+
 ## 2.0.0
 
 - remove support of Ubuntu 18.04 (EOL)

--- a/README.md
+++ b/README.md
@@ -5,14 +5,23 @@ This role configures a Linux-LIO based iSCSI target on a Linux host using `targe
 
 Tested with:
 
-- Ubuntu 20.04
 - Ubuntu 22.04
+- Ubuntu 24.04
+- Ubuntu 26.04
 - Archlinux
 
-Documentation about LIO and Target can be found [here](https://linux-iscsi.org/wiki/Main_Page).
+Documentation about LIO and Target can be found in the [Linux-iSCSI wiki](https://linux-iscsi.org/wiki/Main_Page).
 
 Requirements
 ------------
+
+The custom modules in `library/` only use Python standard library modules together with Ansible's normal module runtime. No additional Python packages need to be installed with `pip` on the managed host.
+
+The managed host still needs:
+
+- a working Python 3 interpreter so Ansible can execute modules
+- the `targetcli` executable, provided by the `targetcli-fb` package on supported distributions
+- existing disks/partitions/LVs if you want to export block devices
 
 This role is not creating any disks/partitions/LVs. It is expected that they are already present on machine or created by some other role. For example: [githubixx.lvm](https://github.com/githubixx/ansible-role-lvm).
 
@@ -46,7 +55,15 @@ Role Variables
 #           - mapped_lunid: 0
 #             lunid: 0
 #     portals:
+#       # IPv4 example
 #       - ip: "0.0.0.0"
+#       # IPv6 example with an explicit address
+#       - ip: "2001:db8::10"
+#       # Dual-stack example with explicit IPv4 and IPv6 portals
+#       - ip: "{{ ansible_facts.get('default_ipv4', {}).get('address', ansible_facts['all_ipv4_addresses'][0]) }}"
+#       - ip: "2001:db8::10"
+#       # Default IPv6 any-address portal example
+#       - ip: "::0"
 #
 # For more information see README.
 iscsi_targets: []
@@ -72,8 +89,9 @@ The configuration above will create an iSCSI setup that will look like this (Out
 #   |     |   o- mapped_lun0 ........................................ [lun0 block/lun_node1 (rw)]
 #   |     o- luns ..................................................................... [LUNs: 1]
 #   |     | o- lun0 ............................. [block/lun_node1 (/dev/vdb) (default_tg_pt_gp)]
-#   |     o- portals ............................................................... [Portals: 1]
-#   |       o- 0.0.0.0:3260 ................................................................ [OK]
+#   |     o- portals ............................................................... [Portals: 2]
+#   |       o- 192.0.2.10:3260 ............................................................ [OK]
+#   |       o- [2001:db8::10]:3260 ........................................................ [OK]
 #   o- loopback .................................................................... [Targets: 0]
 #   o- vhost ....................................................................... [Targets: 0]
 #   o- xen-pvscsi .................................................................. [Targets: 0]
@@ -87,7 +105,9 @@ The configuration above will create an iSCSI setup that will look like this (Out
 
 `mapped_luns` assigns mapped LUNs (logical units) to initiator. Normally `mapped_lunid` and `lunid` matches the same `lunid` in `iscsi_targets.disks`. But it also could be different.
 
-`portals` allows to specify the IP address the iSCSI target service should listen on. E.g. if `0.0.0.0` is specified then the service will listen on all interfaces on port `3260`. Of course Ansible facts can also be used e.g. `{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}`.
+`portals` allows to specify the IP address the iSCSI target service should listen on. IPv4 addresses like `0.0.0.0` and explicit host IPv4 addresses are supported. Explicit IPv6 addresses like `2001:db8::10` are supported as well. For IPv6, the role accepts the plain address and handles the bracketed `targetcli` syntax internally. The special `::0` value maps to targetcli's default IPv6 any-address portal on port `3260`. Of course Ansible facts can also be used e.g. `{{ ansible_facts.get('default_ipv4', {}).get('address', ansible_facts['all_ipv4_addresses'][0]) }}`.
+
+Global `targetcli` preferences are verified after changes are applied. On affected `targetcli` versions, such as Ubuntu 26.04, the role falls back to updating `prefs.bin` if the runtime preference does not reflect the requested value.
 
 ```yaml
 #######################################
@@ -146,13 +166,15 @@ Example Playbook
               - mapped_lunid: 0
                 lunid: 0
         portals:
-          - ip: "0.0.0.0"
+          - ip: "{{ ansible_facts.get('default_ipv4', {}).get('address', ansible_facts['all_ipv4_addresses'][0]) }}"
+          - ip: "2001:db8::10"
 ```
 
 Testing
 -------
 
-This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-iscsi_target/tree/master/molecule/kvm).
+This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The [Molecule default scenario](https://github.com/githubixx/ansible-role-iscsi_target/tree/master/molecule/default) contains the test configuration.
+The verify stage checks targets, backstores, LUNs, ACLs, authentication, mapped LUNs, preferences, and expected portal bindings.
 
 Afterwards molecule can be executed:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,15 @@
 #           - mapped_lunid: 0
 #             lunid: 0
 #     portals:
+#       # IPv4 example
 #       - ip: "0.0.0.0"
+#       # IPv6 example with an explicit address
+#       - ip: "2001:db8::10"
+#       # Dual-stack example with explicit IPv4 and IPv6 portals
+#       - ip: "{{ ansible_facts.get('default_ipv4', {}).get('address', ansible_facts['all_ipv4_addresses'][0]) }}"
+#       - ip: "2001:db8::10"
+#       # Default IPv6 any-address portal example
+#       - ip: "::0"
 #
 # For more information see README.
 iscsi_targets: []

--- a/library/targetcli_backstore.py
+++ b/library/targetcli_backstore.py
@@ -29,7 +29,7 @@ options:
     required: false
     choices: [present, absent]
 notes:
-   - Tested on Archlinux, Ubuntu 20.04
+  - Tested on Archlinux, Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
 requirements: [ ]
 author: "Ondrej Famera <ondrej-xa2iel8u@famera.cz>"
 '''
@@ -43,7 +43,7 @@ remove block backstore from disk/LV /dev/c7vg/LV2
 
 '''
 
-from distutils.spawn import find_executable
+from shutil import which
 
 def main():
         module = AnsibleModule(
@@ -60,7 +60,7 @@ def main():
         if state == 'present' and not module.params['options']:
             module.fail_json(msg="Missing options parameter needed for creating backstore object")
 
-        if find_executable('targetcli') is None:
+        if which('targetcli') is None:
             module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
 
         result = {}

--- a/library/targetcli_iscsi.py
+++ b/library/targetcli_iscsi.py
@@ -20,7 +20,7 @@ options:
     default: present
     choices: [present, absent]
 notes:
-   - Tested on Archlinux, Ubuntu 20.04
+    - Tested on Archlinux, Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
 requirements: [ ]
 author: "Ondrej Famera <ondrej-xa2iel8u@famera.cz>"
 '''
@@ -33,7 +33,7 @@ remove existing target
 - targetcli_iscsi: wwn=iqn.1994-05.com.redhat:hell state=absent
 '''
 
-from distutils.spawn import find_executable
+from shutil import which
 
 def main():
         module = AnsibleModule(
@@ -47,7 +47,7 @@ def main():
         wwn = module.params['wwn']
         state = module.params['state']
 
-        if find_executable('targetcli') is None:
+        if which('targetcli') is None:
             module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
 
         result = {}

--- a/library/targetcli_iscsi_acl.py
+++ b/library/targetcli_iscsi_acl.py
@@ -25,7 +25,7 @@ options:
     default: present
     choices: [present, absent]
 notes:
-   - Tested on Archlinux, Ubuntu 20.04
+  - Tested on Archlinux, Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
 requirements: [ ]
 author: "Ondrej Famera <ondrej-xa2iel8u@famera.cz>"
 '''
@@ -38,7 +38,7 @@ remove iSCSI ACL
 - targetcli_iscsi_acl: wwn=iqn.1994-05.com.redhat:data initiator_wwn=iqn.1994-05.com.redhat:client1 state=absent
 '''
 
-from distutils.spawn import find_executable
+from shutil import which
 
 def main():
         module = AnsibleModule(
@@ -52,7 +52,7 @@ def main():
 
         state = module.params['state']
 
-        if find_executable('targetcli') is None:
+        if which('targetcli') is None:
             module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
 
         result = {}

--- a/library/targetcli_iscsi_auth.py
+++ b/library/targetcli_iscsi_auth.py
@@ -39,7 +39,7 @@ options:
     required: false
     default: null
 notes:
-   - Tested on Archlinux, Ubuntu 20.04
+  - Tested on Archlinux, Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
 requirements: [ ]
 author: "Michel Weitbrecht <michel.weitbrecht@stuvus.uni-stuttgart.de>"
 '''
@@ -56,8 +56,8 @@ set userid and password as well as mutual userid and password
 
 '''
 
-from distutils.spawn import find_executable
 import re
+from shutil import which
 
 
 def main():
@@ -72,7 +72,7 @@ def main():
     ),
     supports_check_mode=True)
 
-  if find_executable('targetcli') is None:
+  if which('targetcli') is None:
     module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
 
   try:
@@ -82,10 +82,10 @@ def main():
 
     rc, out, err = module.run_command(
       "targetcli '/iscsi/%(wwn)s/tpg1/acls/%(initiator_wwn)s get auth'" % module.params)
-    userid = re.search('(?<=userid\=).*(?=\n)', out).group(0)
-    password = re.search('(?<=password\=).*(?=\n)', out).group(0)
-    userid_mutual = re.search('(?<=mutual_userid\=).*(?=\n)', out).group(0)
-    password_mutual = re.search('(?<=mutual_password\=).*(?=\n)', out).group(0)
+    userid = re.search(r'(?<=userid=).*(?=\n)', out).group(0)
+    password = re.search(r'(?<=password=).*(?=\n)', out).group(0)
+    userid_mutual = re.search(r'(?<=mutual_userid=).*(?=\n)', out).group(0)
+    password_mutual = re.search(r'(?<=mutual_password=).*(?=\n)', out).group(0)
 
     if rc != 0:
       module.fail_json(msg="failed to read authentication parameters")

--- a/library/targetcli_iscsi_lun.py
+++ b/library/targetcli_iscsi_lun.py
@@ -35,7 +35,7 @@ options:
     default: present
     choices: [present, absent]
 notes:
-   - Tested on Archlinux, Ubuntu 20.04
+  - Tested on Archlinux, Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
 requirements: [ ]
 authors: "Ondrej Famera <ondrej-xa2iel8u@famera.cz>" and "Ricardo Sanchez <ricsanfre@gmail.com>"
 '''
@@ -48,7 +48,8 @@ remove iSCSI LUN
 - targetcli_iscsi_lun: wwn=iqn.1994-05.com.redhat:hell backstopre_type=block backstore_name=test2 lunid=1 state=absent
 '''
 
-from distutils.spawn import find_executable
+from shutil import which
+
 
 def main():
         module = AnsibleModule(
@@ -67,6 +68,9 @@ def main():
 
         result = {}
         luns = {}
+
+        if which('targetcli') is None:
+          module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
 
         try:
             # check if the iscsi target exists

--- a/library/targetcli_iscsi_mappedlun.py
+++ b/library/targetcli_iscsi_mappedlun.py
@@ -42,7 +42,7 @@ options:
     choices: [present, absent]
 
 notes:
-   - Tested on Archlinux, Ubuntu 20.04
+  - Tested on Archlinux, Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
 requirements: [ ]
 author: "Ricardo Sanchez <ricsanfre@gmail.com>"
 '''
@@ -61,8 +61,8 @@ Remove mapped LUN
 
 '''
 
-from distutils.spawn import find_executable
 import re
+from shutil import which
 
 def main():
   module = AnsibleModule(
@@ -76,7 +76,7 @@ def main():
     ),
     supports_check_mode=True)
 
-  if find_executable('targetcli') is None:
+  if which('targetcli') is None:
     module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
   state = module.params['state']
   initiator_wwn = module.params['initiator_wwn']

--- a/library/targetcli_iscsi_portal.py
+++ b/library/targetcli_iscsi_portal.py
@@ -30,7 +30,7 @@ options:
     default: present
     choices: [present, absent]
 notes:
-   - Tested on Archlinux, Ubuntu 20.04
+  - Tested on Archlinux, Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
 requirements: [ ]
 author: "Michel Weitbrecht <michel.weitbrecht@stuvus.uni-stuttgart.de>"
 '''
@@ -46,53 +46,99 @@ remove the portal
 - targetcli_iscsi_portal: wwn=iqn.2003-01.org.linux-iscsi.storage01.x8664:portaltest ip=192.168.178.55 port=2881 state=absent
 '''
 
-from distutils.spawn import find_executable
+from shutil import which
+
+
+def canonicalize_ip(ip_address):
+    if "." in ip_address:
+        return ip_address
+
+    if ip_address.startswith("[") and ip_address.endswith("]"):
+        return ip_address
+
+    return "[{}]".format(ip_address)
+
+
+def is_default_ipv6_portal(ip_address, port):
+    return ip_address == "::0" and str(port) == "3260"
+
 
 def main():
-        module = AnsibleModule(
-                argument_spec = dict(
-                        wwn=dict(required=True),
-                        ip=dict(required=True),
-                        port=dict(default="3260"),
-                        state=dict(default="present", choices=['present', 'absent']),
-                ),
-                supports_check_mode=True
-        )
+  module = AnsibleModule(
+    argument_spec=dict(
+      wwn=dict(required=True),
+      ip=dict(required=True),
+      port=dict(default="3260"),
+      state=dict(default="present", choices=['present', 'absent']),
+    ),
+    supports_check_mode=True
+  )
 
-        state = module.params['state']
+  state = module.params['state']
+  portal_path_params = dict(module.params)
+  portal_path_params['ip'] = canonicalize_ip(module.params['ip'])
+  portal_cmd_params = dict(module.params)
+  create_command = "targetcli '/iscsi/%(wwn)s/tpg1/portals create %(ip)s %(port)s'" % portal_cmd_params
 
-        if find_executable('targetcli') is None:
-            module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
+  if is_default_ipv6_portal(module.params['ip'], module.params['port']):
+    create_command = "targetcli '/iscsi/%(wwn)s/tpg1/portals create'" % portal_cmd_params
 
-        result = {}
+  if which('targetcli') is None:
+    module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
 
-        try:
-            rc, out, err = module.run_command("targetcli '/iscsi/%(wwn)s/tpg1/portals/%(ip)s:%(port)s status'" % module.params)
-            if rc == 0 and state == 'present':
-                result['changed'] = False
-            elif rc == 0 and state == 'absent':
-                if module.check_mode:
-                    module.exit_json(changed=True)
-                else:
-                    rc, out, err = module.run_command("targetcli '/iscsi/%(wwn)s/tpg1/portals delete %(ip)s %(port)s'" % module.params)
-                    if rc == 0:
-                        module.exit_json(changed=True)
-                    else:
-                        module.fail_json(msg="Failed to delete iSCSI portal object")
-            elif state == 'absent':
-                result['changed'] = False
-            else:
-                if module.check_mode:
-                    module.exit_json(changed=True)
-                else:
-                    rc, out, err = module.run_command("targetcli '/iscsi/%(wwn)s/tpg1/portals create %(ip)s %(port)s'" % module.params)
-                    if rc == 0:
-                        module.exit_json(changed=True)
-                    else:
-                        module.fail_json(msg="Failed to define iSCSI portal object")
-        except OSError as e:
-            module.fail_json(msg="Failed to check iSCSI portal object - %s" %(e) )
-        module.exit_json(**result)
+  result = {}
+
+  try:
+    rc, out, err = module.run_command(
+      "targetcli '/iscsi/%(wwn)s/tpg1/portals/%(ip)s:%(port)s status'" % portal_path_params)
+    if rc == 0 and state == 'present':
+      result['changed'] = False
+    elif rc == 0 and state == 'absent':
+      if module.check_mode:
+        module.exit_json(changed=True)
+      else:
+        rc, out, err = module.run_command(
+          "targetcli '/iscsi/%(wwn)s/tpg1/portals delete %(ip)s %(port)s'" % portal_cmd_params)
+        verify_rc, verify_out, verify_err = module.run_command(
+          "targetcli '/iscsi/%(wwn)s/tpg1/portals/%(ip)s:%(port)s status'" % portal_path_params)
+        if verify_rc != 0:
+          module.exit_json(changed=True)
+        else:
+          module.fail_json(
+            msg="Failed to delete iSCSI portal object",
+            rc=rc,
+            stdout=out,
+            stderr=err,
+            verify_rc=verify_rc,
+            verify_stdout=verify_out,
+            verify_stderr=verify_err,
+          )
+    elif state == 'absent':
+      result['changed'] = False
+    else:
+      if module.check_mode:
+        module.exit_json(changed=True)
+      else:
+        rc, out, err = module.run_command(
+          create_command)
+        verify_rc, verify_out, verify_err = module.run_command(
+          "targetcli '/iscsi/%(wwn)s/tpg1/portals/%(ip)s:%(port)s status'" % portal_path_params)
+        if verify_rc == 0:
+          module.exit_json(changed=True)
+        else:
+          module.fail_json(
+            msg="Failed to define iSCSI portal object",
+            rc=rc,
+            stdout=out,
+            stderr=err,
+            verify_rc=verify_rc,
+            verify_stdout=verify_out,
+            verify_stderr=verify_err,
+          )
+  except OSError as e:
+    module.fail_json(msg="Failed to check iSCSI portal object - %s" % (e))
+
+  module.exit_json(**result)
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/library/targetcli_preferences.py
+++ b/library/targetcli_preferences.py
@@ -25,7 +25,7 @@ options:
     required: true
     default: nulle
 notes:
-   - Tested on Archlinux, Ubuntu 20.04
+    - Tested on Archlinux, Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
 requirements: [ ]
 author: "Ricardo Sanchez <ricsanfre@gmail.com>"
 '''
@@ -36,7 +36,72 @@ define new new value for a global preference
 
 '''
 
-from distutils.spawn import find_executable
+from shutil import which
+import os
+import pickle
+
+
+def read_preference(module, preference):
+    rc, out, err = module.run_command(
+        "targetcli 'get global %(preference)s'" % module.params
+    )
+    if rc != 0:
+        module.fail_json(
+            msg="Failed to read preference",
+            preference=preference,
+            rc=rc,
+            stdout=out,
+            stderr=err,
+        )
+
+    row_data = out.split('\n')[0].split('=', 1)
+    if len(row_data) != 2 or row_data[0] != preference:
+        module.fail_json(
+            msg="Failed to parse preference output",
+            preference=preference,
+            stdout=out,
+            stderr=err,
+        )
+
+    return row_data[1].strip(), out, err
+
+
+def normalize_preference_value(value, current_value=None):
+    lowered = str(value).lower()
+
+    if isinstance(current_value, bool):
+        return lowered == 'true'
+
+    if isinstance(current_value, int):
+        try:
+            return int(value)
+        except ValueError:
+            return value
+
+    if lowered in ('true', 'false'):
+        return lowered == 'true'
+
+    return value
+
+
+def update_preference_file(preference, value):
+    prefs_dir = os.path.join(os.path.expanduser('~'), '.targetcli')
+    prefs_path = os.path.join(prefs_dir, 'prefs.bin')
+
+    if os.path.exists(prefs_path):
+        with open(prefs_path, 'rb') as file_handle:
+            preferences = pickle.load(file_handle)
+    else:
+        preferences = {}
+
+    current_value = preferences.get(preference)
+    preferences[preference] = normalize_preference_value(value, current_value)
+
+    if not os.path.isdir(prefs_dir):
+        os.makedirs(prefs_dir)
+
+    with open(prefs_path, 'wb') as file_handle:
+        pickle.dump(preferences, file_handle)
 
 def main():
         module = AnsibleModule(
@@ -50,28 +115,52 @@ def main():
         preference = module.params['preference']
         value = module.params['value']
 
-        if find_executable('targetcli') is None:
+        if which('targetcli') is None:
             module.fail_json(msg="'targetcli' executable not found. Install 'targetcli'.")
 
         result = {}
 
         try:
-            rc, out, err = module.run_command("targetcli 'get global %(preference)s'" % module.params)
-            row_data = out.split('\n')[0].split('=')
-            already_set = False
-            if row_data[0] == preference and row_data[1].strip() == value:
-                already_set = True
-            if rc == 0 and already_set:
+            current_value, out, err = read_preference(module, preference)
+
+            if current_value == value:
                 result['changed'] = False
-            elif rc == 0 and not already_set:
-                if module.check_mode:
-                    module.exit_json(changed=True)
-                else:
-                    rc, out, err = module.run_command("targetcli 'set global %(preference)s=%(value)s'" % module.params)
-                    if rc == 0:
-                        module.exit_json(changed=True)
-                    else:
-                        module.fail_json(msg="Failed to change preference")
+                module.exit_json(**result)
+
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            rc, set_out, set_err = module.run_command(
+                "targetcli 'set global %(preference)s=%(value)s'" % module.params
+            )
+            if rc != 0:
+                module.fail_json(
+                    msg="Failed to change preference",
+                    preference=preference,
+                    value=value,
+                    rc=rc,
+                    stdout=set_out,
+                    stderr=set_err,
+                )
+
+            updated_value, verify_out, verify_err = read_preference(module, preference)
+            if updated_value == value:
+                module.exit_json(changed=True)
+
+            update_preference_file(preference, value)
+            updated_value, verify_out, verify_err = read_preference(module, preference)
+            if updated_value == value:
+                module.exit_json(changed=True, fallback='prefs.bin')
+
+            module.fail_json(
+                msg="Failed to verify preference change",
+                preference=preference,
+                value=value,
+                stdout=set_out,
+                stderr=set_err,
+                verify_stdout=verify_out,
+                verify_stderr=verify_err,
+            )
         except OSError as e:
             module.fail_json(msg="Failed to check iSCSI object - %s" %(e) )
         module.exit_json(**result)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,8 +10,9 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - "focal"
         - "jammy"
+        - "noble"
+        - "resolute"
   galaxy_tags:
     - system
     - disk

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -1,0 +1,35 @@
+---
+# Copyright (C) 2021-2026 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Remove leftover libvirt volumes
+  hosts: localhost
+  connection: local
+  become: true
+  gather_facts: false
+  vars:
+    iscsi_target__libvirt_uri: qemu:///system
+    iscsi_target__libvirt_pool: default
+    iscsi_target__instance_names:
+      - test-iscsi-ubuntu2204
+      - test-iscsi-ubuntu2404
+      - test-iscsi-ubuntu2604
+      - test-iscsi-archlinux
+  tasks:
+    - name: List matching leftover libvirt volumes
+      ansible.builtin.shell: |
+        set -o pipefail
+        virsh -c {{ iscsi_target__libvirt_uri | quote }} vol-list {{ iscsi_target__libvirt_pool | quote }} | awk '{print $1}' | \
+          grep -E '{{ iscsi_target__instance_names | join("|") }}' || true
+      args:
+        executable: /bin/bash
+      register: iscsi_target__leftover_volumes
+      changed_when: false
+
+    - name: Delete leftover libvirt volumes
+      ansible.builtin.command:
+        cmd: >-
+          virsh -c {{ iscsi_target__libvirt_uri }} vol-delete {{ item }} {{ iscsi_target__libvirt_pool }}
+      loop: "{{ iscsi_target__leftover_volumes.stdout_lines }}"
+      when: iscsi_target__leftover_volumes.stdout_lines | length > 0
+      changed_when: true

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -15,6 +15,7 @@
       - test-iscsi-ubuntu2404
       - test-iscsi-ubuntu2604
       - test-iscsi-archlinux
+      - test-iscsi-initiator-ubuntu2204
   tasks:
     - name: List matching leftover libvirt volumes
       ansible.builtin.shell: |

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,8 +16,8 @@ driver:
     name: libvirt
 
 platforms:
-  - name: ubuntu2004
-    box: generic/ubuntu2004
+  - name: test-iscsi-ubuntu2204
+    box: githubixx/ubuntu-22.04
     memory: 2048
     cpus: 2
     provider_raw_config_args:
@@ -29,8 +29,8 @@ platforms:
         ip: 172.16.10.10
     groups:
       - ubuntu
-  - name: archlinux
-    box: archlinux/archlinux
+  - name: test-iscsi-archlinux
+    box: githubixx/archlinux
     memory: 2048
     cpus: 2
     provider_raw_config_args:
@@ -43,8 +43,8 @@ platforms:
         ip: 172.16.10.20
     groups:
       - archlinux
-  - name: ubuntu2204
-    box: generic/ubuntu2204
+  - name: test-iscsi-ubuntu2404
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     provider_raw_config_args:
@@ -56,12 +56,31 @@ platforms:
         ip: 172.16.10.30
     groups:
       - ubuntu
+  - name: test-iscsi-ubuntu2604
+    box: githubixx/ubuntu-26.04
+    memory: 2048
+    cpus: 2
+    provider_raw_config_args:
+      - "storage :file, :size => '1G', :device => 'vdb'"
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.40
+    groups:
+      - ubuntu
 
 provisioner:
   name: ansible
   playbooks:
     prepare: prepare.yml
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+
+scenario:
+  name: default
+  destroy_sequence:
+    - destroy
+    - cleanup
 
 verifier:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -69,6 +69,17 @@ platforms:
         ip: 172.16.10.40
     groups:
       - ubuntu
+  - name: test-iscsi-initiator-ubuntu2204
+    box: githubixx/ubuntu-22.04
+    memory: 2048
+    cpus: 2
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.50
+    groups:
+      - initiator
 
 provisioner:
   name: ansible

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -38,3 +38,40 @@
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 3600
+
+- name: Setup initiator hosts
+  hosts: initiator
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  vars_files:
+    - vars/initiator.yml
+  tasks:
+    - name: Update APT package cache on initiator hosts
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Install open-iscsi on initiator hosts
+      ansible.builtin.apt:
+        name: open-iscsi
+        state: present
+
+    - name: Configure initiator IQN
+      ansible.builtin.lineinfile:
+        path: /etc/iscsi/initiatorname.iscsi
+        regexp: '^InitiatorName='
+        line: 'InitiatorName={{ iscsi_initiator_test.initiator_iqn }}'
+      notify:
+        - Restart iscsid
+
+    - name: Ensure iscsid is enabled and started
+      ansible.builtin.systemd_service:
+        name: iscsid
+        enabled: true
+        state: started
+  handlers:
+    - name: Restart iscsid
+      ansible.builtin.systemd_service:
+        name: iscsid
+        state: restarted

--- a/molecule/default/vars/archlinux.yml
+++ b/molecule/default/vars/archlinux.yml
@@ -1,4 +1,6 @@
 ---
+iscsi_archlinux_portal_ip: 172.16.10.20
+
 iscsi_targets:
   - name: "iqn.2021-11.blog.tauceti:{{ ansible_facts['nodename'] }}"
     disks:
@@ -14,25 +16,25 @@ iscsi_targets:
       - name: iqn.2021-07.blog.tauceti:node1
         authentication:
           userid: node1user
-          password: node1pw
+          password: node1secret12
           userid_mutual: node1sharedkey
-          password_mutual: node1sharedsecret
+          password_mutual: node1mutual123
         mapped_luns:
           - mapped_lunid: 0
             lunid: 0
       - name: iqn.2021-07.blog.tauceti:node2
         authentication:
           userid: node2user
-          password: node2pw
+          password: node2secret12
           userid_mutual: node2sharedkey
-          password_mutual: node2sharedsecret
+          password_mutual: node2mutual123
         mapped_luns:
           - mapped_lunid: 1
             lunid: 1
     portals:
-      - ip: "{{ ansible_facts.get('default_ipv4', {}).get('address', ansible_facts['all_ipv4_addresses'][0]) }}"
+      - ip: "{{ iscsi_archlinux_portal_ip }}"
       - ip: "::1"
 
 iscsi_expected_portals:
-  - "{{ ansible_facts.get('default_ipv4', {}).get('address', ansible_facts['all_ipv4_addresses'][0]) }}:3260"
+  - "{{ iscsi_archlinux_portal_ip }}:3260"
   - "[::1]:3260"

--- a/molecule/default/vars/archlinux.yml
+++ b/molecule/default/vars/archlinux.yml
@@ -30,4 +30,9 @@ iscsi_targets:
           - mapped_lunid: 1
             lunid: 1
     portals:
-      - ip: "{{ ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0]) }}"
+      - ip: "{{ ansible_facts.get('default_ipv4', {}).get('address', ansible_facts['all_ipv4_addresses'][0]) }}"
+      - ip: "::1"
+
+iscsi_expected_portals:
+  - "{{ ansible_facts.get('default_ipv4', {}).get('address', ansible_facts['all_ipv4_addresses'][0]) }}:3260"
+  - "[::1]:3260"

--- a/molecule/default/vars/initiator.yml
+++ b/molecule/default/vars/initiator.yml
@@ -1,0 +1,13 @@
+---
+iscsi_initiator_test:
+  initiator_iqn: iqn.2021-07.blog.tauceti:node1
+  target_iqn: iqn.2021-11.blog.tauceti:test-iscsi-ubuntu2204
+  target_portal: 172.16.10.10
+  target_port: 3260
+  auth:
+    username: node1user
+    password: node1secret12
+    mutual_username: node1sharedkey
+    mutual_password: node1mutual123
+  expected_luns:
+    - lunid: 0

--- a/molecule/default/vars/ubuntu.yml
+++ b/molecule/default/vars/ubuntu.yml
@@ -18,3 +18,6 @@ iscsi_targets:
             lunid: 0
     portals:
       - ip: "0.0.0.0"
+
+iscsi_expected_portals:
+  - "0.0.0.0:3260"

--- a/molecule/default/vars/ubuntu.yml
+++ b/molecule/default/vars/ubuntu.yml
@@ -10,9 +10,9 @@ iscsi_targets:
       - name: iqn.2021-07.blog.tauceti:node1
         authentication:
           userid: node1user
-          password: node1pw
+          password: node1secret12
           userid_mutual: node1sharedkey
-          password_mutual: node1sharedsecret
+          password_mutual: node1mutual123
         mapped_luns:
           - mapped_lunid: 0
             lunid: 0

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,8 +1,19 @@
 ---
 - name: Verify setup
   hosts: all
+  gather_facts: true
+  pre_tasks:
+    - name: Load scenario vars for current distribution
+      ansible.builtin.include_vars: "{{ item }}"
+      with_first_found:
+        - files:
+            - "vars/{{ ansible_facts['distribution'] | lower }}.yml"
+            - "vars/{{ ansible_facts['os_family'] | lower }}.yml"
+          paths:
+            - "{{ playbook_dir }}"
   vars:
     expected_output: "iqn.2021-11.blog.tauceti:{{ ansible_facts['nodename'] }}"
+    expected_portals: "{{ iscsi_expected_portals | default([]) }}"
   tasks:
     - name: Execute targetcli to capture output
       ansible.builtin.command: targetcli "ls /"
@@ -10,7 +21,38 @@
       changed_when: false
       become: true
 
+    - name: Execute targetcli to capture portal output
+      ansible.builtin.command: targetcli "/iscsi/{{ expected_output }}/tpg1/portals ls"
+      register: targetcli_portals_output
+      changed_when: false
+      become: true
+
     - name: Ensure targetcli output contains correct string
       ansible.builtin.assert:
         that:
           - "expected_output in targetcli_output.stdout"
+
+    - name: Ensure targetcli output contains expected portals
+      ansible.builtin.assert:
+        that:
+          - "item in targetcli_portals_output.stdout"
+      loop: "{{ expected_portals }}"
+
+    - name: Read auto_add_mapped_luns preference
+      ansible.builtin.command: targetcli "get global auto_add_mapped_luns"
+      register: auto_add_mapped_luns_output
+      changed_when: false
+      become: true
+
+    - name: Ensure auto_add_mapped_luns is disabled
+      ansible.builtin.assert:
+        that:
+          - "'false' in auto_add_mapped_luns_output.stdout"
+
+    - name: Verify configured iSCSI targets
+      ansible.builtin.include_tasks:
+        file: verify_target.yml
+      loop: "{{ iscsi_targets | default([]) }}"
+      loop_control:
+        loop_var: target
+        label: "{{ target.name }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,6 +1,6 @@
 ---
-- name: Verify setup
-  hosts: all
+- name: Verify target setup
+  hosts: all:!initiator
   gather_facts: true
   pre_tasks:
     - name: Load scenario vars for current distribution
@@ -56,3 +56,15 @@
       loop_control:
         loop_var: target
         label: "{{ target.name }}"
+
+- name: Verify initiator client setup
+  hosts: initiator
+  gather_facts: true
+  pre_tasks:
+    - name: Load initiator scenario vars
+      ansible.builtin.include_vars:
+        file: vars/initiator.yml
+  tasks:
+    - name: Verify iSCSI client connectivity
+      ansible.builtin.include_tasks:
+        file: verify_initiator_client.yml

--- a/molecule/default/verify_initiator.yml
+++ b/molecule/default/verify_initiator.yml
@@ -1,0 +1,48 @@
+---
+- name: Check ACL exists for {{ initiator.name }}
+  ansible.builtin.command: >-
+    targetcli '/iscsi/{{ target.name }}/tpg1/acls/{{ initiator.name }} status'
+  register: acl_status_output
+  changed_when: false
+  become: true
+
+- name: Ensure ACL exists for {{ initiator.name }}
+  ansible.builtin.assert:
+    that:
+      - acl_status_output.rc == 0
+
+- name: Read authentication for {{ initiator.name }}
+  ansible.builtin.command: >-
+    targetcli '/iscsi/{{ target.name }}/tpg1/acls/{{ initiator.name }} get auth'
+  register: auth_output
+  changed_when: false
+  become: true
+
+- name: Ensure authentication is configured for {{ initiator.name }}
+  ansible.builtin.assert:
+    that:
+      - "('userid=' ~ initiator.authentication.userid) in auth_output.stdout"
+      - "('password=' ~ initiator.authentication.password) in auth_output.stdout"
+      - >-
+        initiator.authentication.userid_mutual is not defined or
+        ('mutual_userid=' ~ initiator.authentication.userid_mutual) in auth_output.stdout
+      - >-
+        initiator.authentication.password_mutual is not defined or
+        ('mutual_password=' ~ initiator.authentication.password_mutual) in auth_output.stdout
+
+- name: Read mapped LUNs for {{ initiator.name }}
+  ansible.builtin.command: >-
+    targetcli '/iscsi/{{ target.name }}/tpg1/acls/{{ initiator.name }} ls'
+  register: mapped_luns_output
+  changed_when: false
+  become: true
+
+- name: Ensure mapped LUNs exist for {{ initiator.name }}
+  ansible.builtin.assert:
+    that:
+      - "('mapped_lun' ~ (mapped_lun.mapped_lunid | string)) in mapped_luns_output.stdout"
+      - "('lun' ~ (mapped_lun.lunid | string)) in mapped_luns_output.stdout"
+  loop: "{{ initiator.mapped_luns | default([]) }}"
+  loop_control:
+    loop_var: mapped_lun
+    label: "{{ mapped_lun.mapped_lunid }}"

--- a/molecule/default/verify_initiator_client.yml
+++ b/molecule/default/verify_initiator_client.yml
@@ -1,0 +1,278 @@
+---
+- name: Verify iSCSI initiator can connect to target
+  block:
+    - name: Ensure initiator IQN is configured for client verification
+      ansible.builtin.lineinfile:
+        path: /etc/iscsi/initiatorname.iscsi
+        regexp: '^InitiatorName='
+        line: 'InitiatorName={{ iscsi_initiator_test.initiator_iqn }}'
+      become: true
+
+    - name: Restart iscsid before client verification
+      ansible.builtin.systemd_service:
+        name: iscsid
+        state: restarted
+      become: true
+
+    - name: Read active initiator IQN
+      ansible.builtin.command:
+        argv:
+          - awk
+          - -F=
+          - '/^InitiatorName=/ {print $2}'
+          - /etc/iscsi/initiatorname.iscsi
+      register: iscsi_initiator_test__active_initiator_name
+      changed_when: false
+      become: true
+
+    - name: Ensure active initiator IQN matches ACL expectations
+      ansible.builtin.assert:
+        that:
+          - iscsi_initiator_test__active_initiator_name.stdout == iscsi_initiator_test.initiator_iqn
+
+    - name: Flush open-iscsi node cache after initiator IQN enforcement
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - node
+          - -o
+          - delete
+      changed_when: false
+      failed_when: false
+      become: true
+
+    - name: Set initiator test portal
+      ansible.builtin.set_fact:
+        iscsi_initiator_test__portal: >-
+          {{ iscsi_initiator_test.target_portal }}:{{ iscsi_initiator_test.target_port }}
+        iscsi_initiator_test__by_path_prefix: >-
+          {{ '/dev/disk/by-path/ip-' ~ iscsi_initiator_test.target_portal ~ ':' ~
+          (iscsi_initiator_test.target_port | string) ~ '-iscsi-' ~
+          iscsi_initiator_test.target_iqn ~ '-lun-' }}
+
+    - name: Log out stale iSCSI session
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - node
+          - -T
+          - "{{ iscsi_initiator_test.target_iqn }}"
+          - -p
+          - "{{ iscsi_initiator_test__portal }}"
+          - --logout
+      register: iscsi_initiator_test__logout_stale
+      changed_when: false
+      failed_when: false
+      become: true
+
+    - name: Remove stale iSCSI node definition
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - node
+          - -T
+          - "{{ iscsi_initiator_test.target_iqn }}"
+          - -p
+          - "{{ iscsi_initiator_test__portal }}"
+          - -o
+          - delete
+      register: iscsi_initiator_test__delete_stale_node
+      changed_when: false
+      failed_when: false
+      become: true
+
+    - name: Discover iSCSI target
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - discovery
+          - -t
+          - st
+          - -p
+          - "{{ iscsi_initiator_test__portal }}"
+      register: iscsi_initiator_test__discovery
+      changed_when: false
+      become: true
+
+    - name: Ensure target discovery returned expected IQN
+      ansible.builtin.assert:
+        that:
+          - iscsi_initiator_test.target_iqn in iscsi_initiator_test__discovery.stdout
+
+    - name: Configure iSCSI node authentication
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - node
+          - -T
+          - "{{ iscsi_initiator_test.target_iqn }}"
+          - -p
+          - "{{ iscsi_initiator_test__portal }}"
+          - --op
+          - update
+          - -n
+          - "{{ item.name }}"
+          - -v
+          - "{{ item.value }}"
+      loop:
+        - name: node.session.auth.authmethod
+          value: CHAP
+        - name: node.session.auth.username
+          value: "{{ iscsi_initiator_test.auth.username }}"
+        - name: node.session.auth.password
+          value: "{{ iscsi_initiator_test.auth.password }}"
+        - name: node.session.auth.username_in
+          value: "{{ iscsi_initiator_test.auth.mutual_username }}"
+        - name: node.session.auth.password_in
+          value: "{{ iscsi_initiator_test.auth.mutual_password }}"
+      loop_control:
+        label: "{{ item.name }}"
+      changed_when: false
+      become: true
+
+    - name: Capture configured iSCSI node authentication
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - node
+          - -T
+          - "{{ iscsi_initiator_test.target_iqn }}"
+          - -p
+          - "{{ iscsi_initiator_test__portal }}"
+          - -o
+          - show
+      register: iscsi_initiator_test__node_config
+      changed_when: false
+      become: true
+
+    - name: Ensure iSCSI node authentication settings are applied
+      ansible.builtin.assert:
+        that:
+          - "'node.session.auth.authmethod = CHAP' in iscsi_initiator_test__node_config.stdout"
+          - "('node.session.auth.username = ' ~ iscsi_initiator_test.auth.username) in iscsi_initiator_test__node_config.stdout"
+          - "('node.session.auth.username_in = ' ~ iscsi_initiator_test.auth.mutual_username) in iscsi_initiator_test__node_config.stdout"
+
+    - name: Log in to iSCSI target
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - node
+          - -T
+          - "{{ iscsi_initiator_test.target_iqn }}"
+          - -p
+          - "{{ iscsi_initiator_test__portal }}"
+          - --login
+      register: iscsi_initiator_test__login
+      changed_when: false
+      become: true
+
+    - name: Capture active iSCSI sessions
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - session
+      register: iscsi_initiator_test__sessions
+      changed_when: false
+      become: true
+
+    - name: Ensure target session is active
+      ansible.builtin.assert:
+        that:
+          - iscsi_initiator_test.target_iqn in iscsi_initiator_test__sessions.stdout
+
+    - name: Wait for expected by-path device links
+      ansible.builtin.wait_for:
+        path: "{{ iscsi_initiator_test__by_path_prefix }}{{ expected_lun.lunid }}"
+        state: present
+        timeout: 30
+      loop: "{{ iscsi_initiator_test.expected_luns }}"
+      loop_control:
+        loop_var: expected_lun
+        label: "lun{{ expected_lun.lunid }}"
+      become: true
+
+    - name: Resolve expected LUN device paths
+      ansible.builtin.command:
+        argv:
+          - readlink
+          - -f
+          - "{{ iscsi_initiator_test__by_path_prefix }}{{ expected_lun.lunid }}"
+      register: iscsi_initiator_test__resolved_devices
+      changed_when: false
+      loop: "{{ iscsi_initiator_test.expected_luns }}"
+      loop_control:
+        loop_var: expected_lun
+        label: "lun{{ expected_lun.lunid }}"
+      become: true
+
+    - name: Ensure resolved LUN device paths exist
+      ansible.builtin.assert:
+        that:
+          - item.stdout.startswith('/dev/')
+      loop: "{{ iscsi_initiator_test__resolved_devices.results }}"
+      loop_control:
+        label: "lun{{ item.expected_lun.lunid }}"
+
+    - name: Perform read-only I/O check on expected LUNs
+      ansible.builtin.command:
+        argv:
+          - dd
+          - if={{ item.stdout }}
+          - of=/dev/null
+          - bs=1M
+          - count=1
+          - status=none
+      register: iscsi_initiator_test__dd
+      changed_when: false
+      loop: "{{ iscsi_initiator_test__resolved_devices.results }}"
+      loop_control:
+        label: "{{ item.stdout }}"
+      become: true
+
+    - name: Ensure read-only I/O checks succeeded
+      ansible.builtin.assert:
+        that:
+          - item.rc == 0
+      loop: "{{ iscsi_initiator_test__dd.results }}"
+      loop_control:
+        label: "{{ item.item.stdout }}"
+
+  always:
+    - name: Log out from iSCSI target
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - node
+          - -T
+          - "{{ iscsi_initiator_test.target_iqn }}"
+          - -p
+          - "{{ iscsi_initiator_test.target_portal }}:{{ iscsi_initiator_test.target_port }}"
+          - --logout
+      changed_when: false
+      failed_when: false
+      become: true
+
+    - name: Remove discovered iSCSI node definition
+      ansible.builtin.command:
+        argv:
+          - iscsiadm
+          - -m
+          - node
+          - -T
+          - "{{ iscsi_initiator_test.target_iqn }}"
+          - -p
+          - "{{ iscsi_initiator_test.target_portal }}:{{ iscsi_initiator_test.target_port }}"
+          - -o
+          - delete
+      changed_when: false
+      failed_when: false
+      become: true

--- a/molecule/default/verify_target.yml
+++ b/molecule/default/verify_target.yml
@@ -1,0 +1,56 @@
+---
+- name: Check target portal group exists for {{ target.name }}
+  ansible.builtin.command: >-
+    targetcli '/iscsi/{{ target.name }}/tpg1 status'
+  register: target_status_output
+  changed_when: false
+  become: true
+
+- name: Ensure target portal group exists for {{ target.name }}
+  ansible.builtin.assert:
+    that:
+      - target_status_output.rc == 0
+
+- name: Check backstore exists
+  ansible.builtin.command: >-
+    targetcli '/backstores/{{ disk.type | default("block") }}/{{ disk.name }} status'
+  register: backstore_status_output
+  changed_when: false
+  become: true
+  loop: "{{ target.disks | default([]) }}"
+  loop_control:
+    loop_var: disk
+    label: "{{ disk.name }}"
+
+- name: Ensure backstores exist for {{ target.name }}
+  ansible.builtin.assert:
+    that:
+      - item.rc == 0
+  loop: "{{ backstore_status_output.results | default([]) }}"
+  loop_control:
+    label: "{{ item.disk.name }}"
+
+- name: Capture LUN output for {{ target.name }}
+  ansible.builtin.command: >-
+    targetcli '/iscsi/{{ target.name }}/tpg1/luns ls'
+  register: luns_output
+  changed_when: false
+  become: true
+
+- name: Ensure expected LUNs exist for {{ target.name }}
+  ansible.builtin.assert:
+    that:
+      - "disk.name in luns_output.stdout"
+      - "('lun' ~ (disk.lunid | string)) in luns_output.stdout"
+  loop: "{{ target.disks | default([]) }}"
+  loop_control:
+    loop_var: disk
+    label: "{{ disk.name }}"
+
+- name: Verify initiators for {{ target.name }}
+  ansible.builtin.include_tasks:
+    file: verify_initiator.yml
+  loop: "{{ target.initiators | default([]) }}"
+  loop_control:
+    loop_var: initiator
+    label: "{{ initiator.name }}"

--- a/tasks/configure-target.yml
+++ b/tasks/configure-target.yml
@@ -29,11 +29,14 @@
     loop_var: "initiator"
   when: target.state | default("present") == "present"
 
-- name: Remove default portal for {{ target.name }}
+- name: Remove default portals for {{ target.name }}
   targetcli_iscsi_portal:
     wwn: "{{ target.name }}"
-    ip: "0.0.0.0"
+    ip: "{{ item }}"
     state: absent
+  loop:
+    - "0.0.0.0"
+    - "::0"
   notify:
     - Save targetcli configuration
   when: target.state | default("present") == "present"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: Load required variables based on the OS type
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_release }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_release'] }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}.yml"
+    - "{{ ansible_facts['os_family'] | lower }}.yml"
   tags:
     - always
 
@@ -14,11 +14,11 @@
   ansible.builtin.include_tasks:
     file: "{{ item }}"
   with_first_found:
-    - "setup-{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}.yml"
-    - "setup-{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}.yml"
-    - "setup-{{ ansible_distribution | lower }}-{{ ansible_distribution_release }}.yml"
-    - "setup-{{ ansible_distribution | lower }}.yml"
-    - "setup-{{ ansible_os_family | lower }}.yml"
+    - "setup-{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "setup-{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "setup-{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_release'] }}.yml"
+    - "setup-{{ ansible_facts['distribution'] | lower }}.yml"
+    - "setup-{{ ansible_facts['os_family'] | lower }}.yml"
 
 - name: Include configure target tasks
   ansible.builtin.include_tasks:

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,6 +1,5 @@
 ---
 iscsi_packages:
-  - python3-distutils
   - targetcli-fb
 
 iscsi_target_service_name: rtslib-fb-targetctl


### PR DESCRIPTION
- remove support for Ubuntu 20.04 (EOL)
- add Ubuntu 24.04 support
- add Ubuntu 26.04 support
- fix custom Ansible modules for Python 3.12 by replacing `distutils.spawn.find_executable`
- Ubuntu: stop installing `python3-distutils`, which is no longer available on Ubuntu 24.04+
- Molecule: remove Ubuntu 20.04 test and add Ubuntu 24.04 and Ubuntu 26.04 tests
- Molecule: remove leftover libvirt volumes during `molecule destroy`
- add dual-stack Molecule coverage and document IPv6 portal support
- handle targetcli default IPv6 portal `::0` as a special create case
- Molecule: strengthen `verify` coverage for targets, backstores, LUNs, ACLs, auth, mapped LUNs, preferences, and portals
- targetcli preferences: verify preference changes and fall back to updating `prefs.bin` when Ubuntu 26.04 `targetcli` reports success without changing state